### PR TITLE
Added option for redirecting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ JSON Web Token authentication requires verifying a signed token. The `'jwt'` sch
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
+- `redirectUrl` - (optional) On error of jwt token instead of replying this will automaticly redirect the user.
 
 See the example folder for an executable example.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,33 +31,40 @@ internals.implementation = function (server, options) {
   var scheme = {
     authenticate: function (request, reply) {
 
+      function ReplyOrRedirect(hapiError) {
+        if(settings.redirectUrl) {
+          return reply.redirect(settings.redirectUrl);
+        }
+        return reply(hapiError);
+      }
+
       var req = request.raw.req;
       var authorization = req.headers.authorization;
       if (!authorization) {
-        return reply(Boom.unauthorized(null, 'Bearer'));
+        return ReplyOrRedirect(Boom.unauthorized(null, 'Bearer'));
       }
 
       var parts = authorization.split(/\s+/);
 
       if (parts.length !== 2) {
-        return reply(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
+        return ReplyOrRedirect(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
       }
 
       if (parts[0].toLowerCase() !== 'bearer') {
-        return reply(Boom.unauthorized(null, 'Bearer'));
+        return ReplyOrRedirect(Boom.unauthorized(null, 'Bearer'));
       }
 
       if(parts[1].split('.').length !== 3) {
-        return reply(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
+        return ReplyOrRedirect(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
       }
 
       var token = parts[1];
 
       jwt.verify(token, settings.key, function(err, decoded) {
         if(err && err.message === 'jwt expired') {
-          return reply(Boom.unauthorized('Expired token received for JSON Web Token validation', 'Bearer'));
+          return ReplyOrRedirect(Boom.unauthorized('Expired token received for JSON Web Token validation', 'Bearer'));
         } else if (err) {
-          return reply(Boom.unauthorized('Invalid signature received for JSON Web Token validation', 'Bearer'));
+          return ReplyOrRedirect(Boom.unauthorized('Invalid signature received for JSON Web Token validation', 'Bearer'));
         }
 
         if (!settings.validateFunc) {
@@ -70,16 +77,16 @@ internals.implementation = function (server, options) {
           credentials = credentials || null;
 
           if (err) {
-            return reply(err, { credentials: credentials, log: { tags: ['auth', 'jwt'], data: err } });
+            return ReplyOrRedirect(err, { credentials: credentials, log: { tags: ['auth', 'jwt'], data: err } });
           }
 
           if (!isValid) {
-            return reply(Boom.unauthorized('Invalid token', 'Bearer'), { credentials: credentials });
+            return ReplyOrRedirect(Boom.unauthorized('Invalid token', 'Bearer'), { credentials: credentials });
           }
 
           if (!credentials || typeof credentials !== 'object') {
 
-            return reply(Boom.badImplementation('Bad credentials object received for jwt auth validation'), { log: { tags: 'credentials' } });
+            return ReplyOrRedirect(Boom.badImplementation('Bad credentials object received for jwt auth validation'), { log: { tags: 'credentials' } });
           }
 
           // Authenticated


### PR DESCRIPTION
We have a case where we want to redirect our user to our login page.  We can't do the redirect on the client since we check the token before even returning any client side code (server side rendered index).  

I simply added a wrapper to the reply to check if a redirectUrl is set.  If the Url is set reply.redirect to that instead of returning a 400, 401.  Additionally if the validate is rejects the token it will follow same logic of redirecting if a url is available.