### PR TITLE
hapi 8.0 support

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ internals.implementation = function (server, options) {
         }
 
         if (!settings.validateFunc) {
-          return reply(null, { credentials: decoded });
+          return reply.continue({ credentials: decoded });
         }
 
 


### PR DESCRIPTION
My guess is this will be added in time (and this is only the first problem I came across so far).  

At least this can act as a pull request sitting out there for folks to see if they are banging their head against a wall when they migrate to hapi 8.x

I have no idea on the best way to support 7 and 8 - Check against the version in package.json?  Hapi.version is also gone, so we can't even take that in as an input.  Anyway, feel free to not merge.  All my stuff (all one app) is in 8, so that's my motivation.

~Ed
