### PR TITLE
validateFunc can return authentication artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ JSON Web Token authentication requires verifying a signed token. The `'jwt'` sch
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
+        - `artifacts` - (optional) an artifact object received from the authentication strategy and used in authentication-related actions.
 
 See the example folder for an executable example.
 
@@ -39,7 +40,7 @@ var accounts = {
 
 var privateKey = 'BbZJjyoXAdr8BUZuiKKARWimKfrSmQ6fv8kZ7OFfc';
 
-// Use this token to build your request with the 'Authorization' header.  
+// Use this token to build your request with the 'Authorization' header.
 // Ex:
 //     Authorization: Bearer <token>
 var token = jwt.sign({ accountId: 123 }, privateKey);
@@ -54,7 +55,9 @@ var validate = function (decodedToken, callback) {
         return callback(error, false, credentials);
     }
 
-    return callback(error, true, credentials)
+    var artifacts = { token : decodedToken };
+
+    return callback(error, true, credentials, artifacts)
 };
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,16 +65,22 @@ internals.implementation = function (server, options) {
         }
 
 
-        settings.validateFunc(decoded, function (err, isValid, credentials) {
+        settings.validateFunc(decoded, function (err, isValid, credentials, artifacts) {
 
           credentials = credentials || null;
 
+          var authResult = { credentials : credentials };
+
+          if (artifacts) {
+            authResult.artifacts = artifacts;
+          }
+
           if (err) {
-            return reply(err, null, { credentials: credentials });
+            return reply(err, null, authResult);
           }
 
           if (!isValid) {
-            return reply(Boom.unauthorized('Invalid token', 'Bearer'), null, { credentials: credentials });
+            return reply(Boom.unauthorized('Invalid token', 'Bearer'), null, authResult);
           }
 
           if (!credentials || typeof credentials !== 'object') {
@@ -84,7 +90,7 @@ internals.implementation = function (server, options) {
 
           // Authenticated
 
-          return reply.continue({ credentials: credentials });
+          return reply.continue(authResult);
         });
 
       });


### PR DESCRIPTION
> `artifacts` - an artifact object received from the authentication strategy and used in authentication-related actions.

http://hapijs.com/api#request-object

Allows `validateFunc` to pass a fourth optional parameter to its callback. A typical use of this would be to make the decoded token available to handlers, since you may not have access to it if your `validateFunc` does not include it in `credentials` (e.g. if you return a user model for credentials).
