### PR TITLE
Added option for redirecting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ JSON Web Token authentication requires verifying a signed token. The `'jwt'` sch
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
-
+        - redirectUrl` - (optional) On error of jwt token instead of replying this will automaticly redirect the user.
+ 
 See the example folder for an executable example.
 
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,25 +30,31 @@ internals.implementation = function (server, options) {
 
   var scheme = {
     authenticate: function (request, reply) {
-
+      function ReplyOrRedirect(hapiError) {
+        if(settings.redirectUrl) {
+          return reply.redirect(settings.redirectUrl);
+        }
+        return reply(hapiError);
+      }
+      
       var req = request.raw.req;
       var authorization = req.headers.authorization;
       if (!authorization) {
-        return reply(Boom.unauthorized(null, 'Bearer'));
+        return ReplyOrRedirect(Boom.unauthorized(null, 'Bearer'));
       }
 
       var parts = authorization.split(/\s+/);
 
       if (parts.length !== 2) {
-        return reply(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
+        return ReplyOrRedirect(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
       }
 
       if (parts[0].toLowerCase() !== 'bearer') {
-        return reply(Boom.unauthorized(null, 'Bearer'));
+        return ReplyOrRedirect(Boom.unauthorized(null, 'Bearer'));
       }
 
       if(parts[1].split('.').length !== 3) {
-        return reply(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
+        return ReplyOrRedirect(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
       }
 
       var token = parts[1];
@@ -57,7 +63,7 @@ internals.implementation = function (server, options) {
         if(err && err.message === 'jwt expired') {
           return reply(Boom.unauthorized('Expired token received for JSON Web Token validation', 'Bearer'));
         } else if (err) {
-          return reply(Boom.unauthorized('Invalid signature received for JSON Web Token validation', 'Bearer'));
+          return ReplyOrRedirect(Boom.unauthorized('Invalid signature received for JSON Web Token validation', 'Bearer'));
         }
 
         if (!settings.validateFunc) {
@@ -70,16 +76,16 @@ internals.implementation = function (server, options) {
           credentials = credentials || null;
 
           if (err) {
-            return reply(err, null, { credentials: credentials });
+            return ReplyOrRedirect(err, null, { credentials: credentials });
           }
 
           if (!isValid) {
-            return reply(Boom.unauthorized('Invalid token', 'Bearer'), null, { credentials: credentials });
+            return ReplyOrRedirect(Boom.unauthorized('Invalid token', 'Bearer'), null, { credentials: credentials });
           }
 
           if (!credentials || typeof credentials !== 'object') {
 
-            return reply(Boom.badImplementation('Bad credentials object received for jwt auth validation'), null, { log: { tags: 'credentials' } });
+            return ReplyOrRedirect(Boom.badImplementation('Bad credentials object received for jwt auth validation'), null, { log: { tags: 'credentials' } });
           }
 
           // Authenticated

--- a/test/index.js
+++ b/test/index.js
@@ -313,4 +313,29 @@ describe('Token', function () {
     done();
   });
 
+  it('redirects instead of replying if redirectUrl is provided', function(done) {
+    var handler = function () {};
+
+    var server = new Hapi.Server({ debug: false });
+    var redirectUrl = "http://testUrl";
+    server.connection();
+    server.register(require('../'), function (err) {
+      expect(err).to.not.exist;
+
+      server.auth.strategy('token', 'jwt', 'required', { key: privateKey + 'a', redirectUrl: redirectUrl });
+
+      server.route([
+        { method: 'POST', path: '/token', handler: handler, config: { auth: 'token' } }
+      ]);
+    });
+
+    var request = { method: 'POST', url: '/token', headers: { authorization: tokenHeader('nullman') } };
+
+    server.inject(request, function (res) {
+      expect(res.statusCode).to.equal(302);
+      expect(res.headers).to.exist;
+      expect(res.headers.location).to.equal(redirectUrl);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
We have a case where we want to redirect our user to our login page. We can't do the redirect on the client since we check the token before even returning any client side code (server side rendered index).

I simply added a wrapper to the reply to check if a redirectUrl is set. If the Url is set reply.redirect to that instead of returning a 400, 401. Additionally if the validate is rejects the token it will follow same logic of redirecting if a url is available.

Updated the pull request to include the hapi 8 upgrade.  My previous pull request can be removed.