### PR TITLE
Upgrade jsonwebtoken to version 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "boom": "2.x.x",
     "hoek": "2.x.x",
-    "jsonwebtoken": "4.2.x"
+    "jsonwebtoken": "5.0.x"
   },
   "peerDependencies": {
     "hapi": ">=8.x.x"


### PR DESCRIPTION
Introduces a critical security fix to the module. For more information,
see https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/