### PR TITLE
Allow extra options (issuer, audience, etc) to be configured

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ internals.implementation = function (server, options) {
 
       var token = parts[1];
 
-      jwt.verify(token, settings.key, function(err, decoded) {
+      jwt.verify(token, settings.key, settings.options || {}, function(err, decoded) {
         if(err && err.message === 'jwt expired') {
           return reply(Boom.unauthorized('Expired token received for JSON Web Token validation', 'Bearer'));
         } else if (err) {


### PR DESCRIPTION
I've added functionality to configure extra options in the verify method to support. These are required options if you need to have [Auth0 integration](https://auth0.com/docs/server-apis/nodejs#2-configure-express-jwt-with-your-auth0-account) for example in your application.